### PR TITLE
add npm run build (noop with a helpful message)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:update-snapshots": "karma start karma.conf.cjs --update-snapshots",
     "test:prune-snapshots": "karma start karma.conf.cjs --prune-snapshots",
     "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js",
-    "build": "echo \"This is not a TypeScript project, so no need to build. (You can ignore the guide where it says 'npm run build'.)\""
+    "build": "echo \"This is not a TypeScript project, so no need to build.\""
   },
   "keywords": [
     "web-components",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test:watch": "karma start karma.conf.cjs --auto-watch=true --single-run=false",
     "test:update-snapshots": "karma start karma.conf.cjs --update-snapshots",
     "test:prune-snapshots": "karma start karma.conf.cjs --prune-snapshots",
-    "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js"
+    "checksize": "rollup -c ; cat my-element.bundled.js | gzip -9 | wc -c ; rm my-element.bundled.js",
+    "build": "echo \"This is not a TypeScript project, so no need to build. (You can ignore the guide where it says 'npm run build'.)\""
   },
   "keywords": [
     "web-components",


### PR DESCRIPTION
The [guide](https://lit-element.polymer-project.org/guide/start) notes that `npm run build` is only necessary for TypeScript, but it's easier to skip over that when you're scanning. It's mentioned again under "Rename Your Component" without a reminder that this is only for TypeScript.

This changed adds a `build` script that does nothing but remind the user they can skip that step.  